### PR TITLE
ignore node_modules tree from tree-shaking as well

### DIFF
--- a/src/graph.js
+++ b/src/graph.js
@@ -148,7 +148,11 @@ class Graph {
     let files = walkSync(this._treePath, {
       directories: false,
       globs: ['**/*.js'],
-      ignore: ['vendor', 'bower_components']
+      ignore: [
+        'bower_components',
+        'node_modules',
+        'vendor'
+      ]
     });
 
     let dead = new Set(files.map(path.normalize));


### PR DESCRIPTION
Closes https://github.com/kellyselden/ember-cli-tree-shaker/issues/9

cc @Turbo87